### PR TITLE
Crash fix due to unrecognized selector has been fixed.

### DIFF
--- a/WKYTPlayer/WKYTPlayerView.m
+++ b/WKYTPlayer/WKYTPlayerView.m
@@ -997,8 +997,11 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
  * @param jsToExecute The JavaScript code in string format that we want to execute.
  */
 - (void)stringFromEvaluatingJavaScript:(NSString *)jsToExecute completionHandler:(void (^ __nullable)(NSString * __nullable response, NSError * __nullable error))completionHandler{
-    [self.webView evaluateJavaScript:jsToExecute completionHandler:^(NSString * _Nullable response, NSError * _Nullable error) {
+    [self.webView evaluateJavaScript:jsToExecute completionHandler:^(id _Nullable response, NSError * _Nullable error) {
         if (completionHandler) {
+            if (![response isKindOfClass:[NSString class]]) {
+                response = nil; // js is somehow returning unexpected type values while we only expect string values.
+            }
             completionHandler(response, error);
         }
     }];


### PR DESCRIPTION
We observed a crash from the library and fixed the issue. The response is originally untyped as it is 'id'. Specifically, we observed that response is a NSNull, not NSString. Due to unsafe typecasting, it ended up with a crash with unrecognized selector assertion.